### PR TITLE
Back to "transparency and trust" from "security"

### DIFF
--- a/ietf-scitt-charter.md
+++ b/ietf-scitt-charter.md
@@ -4,9 +4,7 @@ Over the years, rapid technological advancements have motivated organizations to
 While these improvements help organizations increase efficiency and swiftly bring innovations to market, the rapid increase in scale, size, and complexity of supply chains has led to more frequent and sophisticated supply chain attacks.
 The traditional methods of safeguarding supply chains (e.g., pre- and post-audit methodologies) are no longer adequate.
 
-The output of the SCITT WG is a set of standards that define the essential building blocks enabling the security of supply chain systems and assisting implementers in securing deployments.
-For example, a public computer interface system could report its software composition, which can be compared against known software compositions for such a device, as recorded in an append-only transparent registry.
-Therefore, providing an individual using the system with confidence that it will behave as and when expected, consistently and without deviation.
+SCITT forms a set of interoperable building blocks that will allow implementers to build integrity and accountability into supply chain systems to help assure trustworthy operation. For example, a public computer interface system could report its software composition that can then be compared against known software compositions (and certifications?) for such a device thereby giving confidence that the system is running the software expected and has not been modified, either by attack or accident, in the supply chain.
 
 Problem Statement
 =================


### PR DESCRIPTION
There was a discussion with me, @or13 and @kaywilliams on the other PR that wasn't addressed, and I think is very important.

I'm concerned that we're swerving a little into the 'preventative security' world where actually the work here is transparency and accountability. In the example given we don't have total confidence that the computer will always behave perfectly: even with the 'right' software payload there may be bugs or operator-borne attacks, for example. But what we do have is confidence that you're dealing with the computer system you thought you would be, and that nothing has been injected or modified on its way to you.

I also removed "an individual" because humans aren't realistically going to be doing much of this transactional verification: we want all of this stuff to be strong enough that we can automate all the mundane validation work away.